### PR TITLE
Allow multiple `root` routes in same scope level

### DIFF
--- a/actionpack/CHANGELOG.md
+++ b/actionpack/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow multiple `root` routes in same scope level. Example:
+
+    ```ruby
+    root 'blog#show', constraints: ->(req) { Hostname.blog_site?(req.host) }
+    root 'landing#show'
+    ```
+    *Rafael Sales*
+
 *   Fix regression in mounted engine named routes generation for app deployed to
     a subdirectory. `relative_url_root` was prepended to the path twice (e.g.
     "/subdir/subdir/engine_path" instead of "/subdir/engine_path")

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -402,7 +402,8 @@ module ActionDispatch
         # because this means it will be matched first. As this is the most popular route
         # of most Rails applications, this is beneficial.
         def root(options = {})
-          match '/', { :as => :root, :via => :get }.merge!(options)
+          name = has_named_route?(:root) ? nil : :root
+          match '/', { as: name, via:  :get }.merge!(options)
         end
 
         # Matches a url pattern to one or more routes.
@@ -1867,7 +1868,7 @@ to this:
               # and return nil in case it isn't. Otherwise, we pass the invalid name
               # forward so the underlying router engine treats it and raises an exception.
               if as.nil?
-                candidate unless candidate !~ /\A[_a-z]/i || @set.named_routes.key?(candidate)
+                candidate unless candidate !~ /\A[_a-z]/i || has_named_route?(candidate)
               else
                 candidate
               end


### PR DESCRIPTION
When an application has multiple root entries with different
constraints, the current solution is to use `get '/'`. Example:

**Currently I have to do:**

``` ruby
get '/', to: 'portfolio#show', constraints: ->(req) { Hostname.portfolio_site?(req.host) }
get '/', to: 'blog#show',      constraints: ->(req) { Hostname.blog_site?(req.host) }
root 'landing#show'
```

**But I would like to do:**

``` ruby
root 'portfolio#show', constraints: ->(req) { Hostname.portfolio_site?(req.host) }
root 'blog#show',      constraints: ->(req) { Hostname.blog_site?(req.host) }
root 'landing#show'
```

Other URL matchers such as `get`, `post`, etc, already allows this, so I
think it's fair that `root` also allow it since it's just a shortcut for
a `get` internally.
