### PR TITLE
Move PredicateBuilder.references to QueyMethods.tables_referenced_in

### DIFF
--- a/activerecord/lib/active_record/relation.rb
+++ b/activerecord/lib/active_record/relation.rb
@@ -613,7 +613,7 @@ module ActiveRecord
     def eager_loading?
       @should_eager_load ||=
         eager_load_values.any? ||
-        includes_values.any? && (joined_includes_values.any? || references_eager_loaded_tables?)
+        includes_values.any? && (joined_includes_values.any? || references_non_joined_tables?)
     end
 
     # Joins that are also marked for preloading. In which case we should just eager load them.
@@ -692,7 +692,8 @@ module ActiveRecord
       ActiveRecord::Associations::Preloader.new
     end
 
-    def references_eager_loaded_tables?
+    # Returns true if there are referenced tables that are not present in join clauses
+    def references_non_joined_tables?
       joined_tables = arel.join_sources.map do |join|
         if join.is_a?(Arel::Nodes::StringJoin)
           tables_in_string(join.left)

--- a/activerecord/lib/active_record/relation/predicate_builder.rb
+++ b/activerecord/lib/active_record/relation/predicate_builder.rb
@@ -46,17 +46,6 @@ module ActiveRecord
       build(table.arel_attribute(column), value)
     end
 
-    def self.references(attributes)
-      attributes.map do |key, value|
-        if value.is_a?(Hash)
-          key
-        else
-          key = key.to_s
-          key.split('.'.freeze).first if key.include?('.'.freeze)
-        end
-      end.compact
-    end
-
     # Define how a class is converted to Arel nodes when passed to +where+.
     # The handler can be any object that responds to +call+, and will be used
     # for any value that +===+ the class given. For example:


### PR DESCRIPTION
- `PredicateBuilder.references method` can/will now be used in `group` method,
  which is not a SQL predicate part.
- Also renamed `references_eager_loaded_tables?` to be more clear with
  what it actually does.
